### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,10 @@
 name: Mark stale issues and pull requests
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
   - cron: "0 0 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/auto-lighthouse-up/security/code-scanning/1](https://github.com/deadjdona/auto-lighthouse-up/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. The `actions/stale` action requires the ability to read and write to issues and pull requests, as it posts comments, adds labels, and closes stale issues or pull requests. Therefore, the minimal permissions required are `contents: read`, `issues: write`, and `pull-requests: write`. These permissions should be added at the workflow level to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
