### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,5 +1,8 @@
 name: Labeler
 on: [pull_request_target]
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/auto-lighthouse-up/security/code-scanning/2](https://github.com/deadjdona/auto-lighthouse-up/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. The `actions/labeler@v2` action requires `contents: read` to access repository contents and `pull-requests: write` to add labels to pull requests. These permissions should be explicitly defined at the workflow level to ensure the `GITHUB_TOKEN` has only the necessary permissions.

The `permissions` block will be added at the root level of the workflow, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
